### PR TITLE
Fix maybe util's file test due to changed behavior of Confita

### DIFF
--- a/maybe/util/file_test.go
+++ b/maybe/util/file_test.go
@@ -18,7 +18,9 @@ func Test_FileBackend_OriginalDecoratesErrorIsPreserved(t *testing.T) {
 		NewFileBackend("testdata/unsupported.cfg"),
 	)
 
-	dummyTo := struct{}{}
+	dummyTo := struct {
+		Dummy string `config:"dummy"`
+	}{}
 	err := loader.Load(context.Background(), &dummyTo)
 	require.Error(t, err)
 	// NOTE: not a best idea ever to rely on an implementation detail; currently there is no better way


### PR DESCRIPTION
Extend dummy target serializable structure with a public field. That allows Loader's enumeration runs and dispatch backend's unmarshaller.